### PR TITLE
Add a Settings item to optionally disable auto capitalization

### DIFF
--- a/ArmenianAppForKeyboard/Armenian/Alpha.m
+++ b/ArmenianAppForKeyboard/Armenian/Alpha.m
@@ -68,7 +68,7 @@
     
     // Row 4
     UIView* row4 = [self createRow:@[ @"զ", @"ղ", @"ց", @"վ", @"բ", @"ն", @"մ" ]
-                           options:nil OffsetLeft:0.11 OffsetLeft:0.11];
+                           options:nil OffsetLeft:0.18 OffsetLeft:0.18];
     row4.backgroundColor = [[UIColor yellowColor] colorWithAlphaComponent:kDebug];
     
     // Add delete button
@@ -134,7 +134,7 @@
     
     // Row 4
     UIView* row4 = [self createRow:@[ @"Զ", @"Ղ", @"Ց", @"Վ", @"Բ", @"Ն", @"Մ"]
-                           options:nil  OffsetLeft:0.11 OffsetLeft:0.11];
+                           options:nil  OffsetLeft:0.18 OffsetLeft:0.18];
     row4.backgroundColor = [[UIColor yellowColor] colorWithAlphaComponent:kDebug];
     
     // Add delete button
@@ -200,7 +200,7 @@
     
     // Row 4
     UIView* row4 = [self createRow:@[ @".", @",", @"?", @"!", @"‘" ]
-                           options:nil  OffsetLeft:0.11 OffsetLeft:0.11];
+                           options:nil  OffsetLeft:0.18 OffsetLeft:0.18];
     row4.backgroundColor = [[UIColor yellowColor] colorWithAlphaComponent:kDebug];
     
     // Add delete button
@@ -266,7 +266,7 @@
     
     // Row 4
     UIView* row4 = [self createRow: @[ @".", @",", @"?", @"!", @"‘" ]
-                           options:nil  OffsetLeft:0.11 OffsetLeft:0.11];
+                           options:nil  OffsetLeft:0.18 OffsetLeft:0.18];
     row4.backgroundColor = [[UIColor yellowColor] colorWithAlphaComponent:kDebug];
     
     // Add delete button

--- a/ArmenianAppForKeyboard/Armenian/KeyboardViewController.m
+++ b/ArmenianAppForKeyboard/Armenian/KeyboardViewController.m
@@ -36,6 +36,7 @@
 // Helper variables
 @property (nonatomic) BOOL isLandscape;
 @property (nonatomic) BOOL isPredictionEnabled;
+@property (nonatomic) BOOL isAutoCapitalizationEnabled;
 
 // Variables for storing keyboard height on landscape and portrait modes
 @property (nonatomic) CGFloat portraitHeight;
@@ -119,6 +120,13 @@
         [userDefaults setBool:NO forKey:@"ArmKeyboardBoldText"];
     }
     ((Colors*)[Colors sharedManager]).isBoldEnabled = [userDefaults boolForKey:@"ArmKeyboardBoldText"];
+    
+    
+    if ([userDefaults objectForKey:@"ArmKeyboardAutoCapitalization"] == nil)
+    {
+        [userDefaults setBool:YES forKey:@"ArmKeyboardAutoCapitalization"];
+    }
+    self.isAutoCapitalizationEnabled = [userDefaults boolForKey:@"ArmKeyboardAutoCapitalization"];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -249,7 +257,8 @@
     [self.view addConstraint:alphaKeyboardButtonTopConstraint];
     
     // Update the keyboard mode on startup
-    if ((self.textDocumentProxy.autocapitalizationType == UITextAutocapitalizationTypeWords ||
+    if (self.isAutoCapitalizationEnabled &&
+        (self.textDocumentProxy.autocapitalizationType == UITextAutocapitalizationTypeWords ||
          self.textDocumentProxy.autocapitalizationType == UITextAutocapitalizationTypeSentences ||
          self.textDocumentProxy.autocapitalizationType == UITextAutocapitalizationTypeAllCharacters) &&
         (self.textDocumentProxy.documentContextBeforeInput == nil ||
@@ -437,7 +446,7 @@
         text = [NSString stringWithString:self.textDocumentProxy.documentContextBeforeInput];
     
     // Check for switching to shited mode
-    if ([text hasSuffix:@": "])
+    if (self.isAutoCapitalizationEnabled && [text hasSuffix:@": "])
     {
         // Switch to shited mode
         [self toShifted];

--- a/ArmenianAppForKeyboard/ArmenianAppForKeyboard/KeyboardSetup.m
+++ b/ArmenianAppForKeyboard/ArmenianAppForKeyboard/KeyboardSetup.m
@@ -79,7 +79,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 3;
+    return 4;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -147,6 +147,24 @@
             BCSwitch.on = [userDefaults boolForKey:@"ArmKeyboardBoldText"];
             [cell.contentView addSubview:BCSwitch];
         }
+        
+        if (indexPath.row == 3)
+        {
+            // Add Auto Capitalization option label
+            UILabel* TClabel = [[UILabel alloc] initWithFrame:CGRectMake(11, 21, self.frame.size.width / 2, 22)];
+            TClabel.font = [UIFont fontWithName:@"OpenSans" size:18.f];
+            TClabel.text = @"Auto Capitalization";
+            TClabel.textColor = tableView.separatorColor = [UIColor colorWithRed:65.f/255.f green:65.f/255.f blue:65.f/255.f alpha:1.f];
+            TClabel.textAlignment = NSTextAlignmentLeft;
+            [cell.contentView addSubview:TClabel];
+
+            // Add Auto Capitalization switch
+            UISwitch* BCSwitch = [[UISwitch alloc] initWithFrame:CGRectMake(self.frame.size.width - 55 - 11, 14,
+                                                                            126, 44)];
+            [BCSwitch addTarget:self action: @selector(autoCapitalization:) forControlEvents:UIControlEventValueChanged];
+            BCSwitch.on = [userDefaults boolForKey:@"ArmKeyboardAutoCapitalization"];
+            [cell.contentView addSubview:BCSwitch];
+        }
     }
     return cell;
 }
@@ -177,6 +195,14 @@
     UISwitch* BCSwitch  = (UISwitch*)sender;
     NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.com.levonpoghosyan.armeniankeyboard"];
     [userDefaults setBool:BCSwitch.on forKey:@"ArmKeyboardBoldText"];
+    [userDefaults synchronize];
+}
+
+- (void)autoCapitalization:(id)sender
+{
+    UISwitch* BCSwitch  = (UISwitch*)sender;
+    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.com.levonpoghosyan.armeniankeyboard"];
+    [userDefaults setBool:BCSwitch.on forKey:@"ArmKeyboardAutoCapitalization"];
     [userDefaults synchronize];
 }
 

--- a/ArmenianAppForKeyboard/ArmenianAppForKeyboard/ViewController.m
+++ b/ArmenianAppForKeyboard/ArmenianAppForKeyboard/ViewController.m
@@ -178,6 +178,12 @@
         [userDefaults setBool:NO forKey:@"ArmKeyboardBoldText"];
         [userDefaults synchronize];
     }
+    if ([userDefaults objectForKey:@"ArmKeyboardAutoCapitalization"] == nil)
+    {
+        NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.com.levonpoghosyan.armeniankeyboard"];
+        [userDefaults setBool:YES forKey:@"ArmKeyboardAutoCapitalization"];
+        [userDefaults synchronize];
+    }
     
     SwipeView* swipeView = [[SwipeView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height)];
     swipeView.delegate = self;


### PR DESCRIPTION
The default value is on to not change any existing behavior for the current users.

<img width="335" alt="screen shot 2018-11-25 at 4 13 46 pm" src="https://user-images.githubusercontent.com/5208783/48978958-6fd51e80-f0cd-11e8-882b-bdc54a107f0f.png">


Also tried to make the letters in the last row the same size as other rows. Was there any reason to not do that? Not sure if I didn't break anything.

<img width="498" alt="screen shot 2018-11-25 at 4 00 09 pm" src="https://user-images.githubusercontent.com/5208783/48978864-d22d1f80-f0cb-11e8-9bd1-210758137a4e.png">

I'm not an iOS dev so let me know if I've done something wrong.

Thanks you for the only good iOS Armenian keyboard!